### PR TITLE
feat: Implement dedicated settings modal for voice selection

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { useEffect, useState } from "react"
+import SettingsModal from "../components/SettingsModal"
 
 interface Problem {
   id: number
@@ -15,6 +16,7 @@ export default function DictationPage() {
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([])
   const [selectedVoice, setSelectedVoice] = useState<string>("")
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null)
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
 
   // 音声一覧取得
   useEffect(() => {
@@ -124,6 +126,12 @@ export default function DictationPage() {
         >
           Dictsy
         </h1>
+        <button
+          onClick={() => setIsSettingsModalOpen(true)}
+          className="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600"
+        >
+          ⚙️ Settings
+        </button>
         <div className="flex items-center gap-2 text-lg text-gray-600 dark:text-gray-300 mb-2">
           <span className="inline-block text-indigo-500 animate-bounce">
             🎧
@@ -143,29 +151,7 @@ export default function DictationPage() {
             <span className="animate-pulse">✨</span>
             <span>Dictsyで楽しくディクテーション！</span>
           </div>
-          {/* 音声選択UI */}
-          <div className="w-full flex flex-col sm:flex-row gap-2 items-center justify-center mb-2">
-            <label
-              className="text-sm text-gray-500 dark:text-gray-400 font-semibold"
-              htmlFor="voice-select"
-            >
-              音声:
-            </label>
-            <select
-              id="voice-select"
-              className="rounded px-2 py-1 border border-indigo-200 dark:border-gray-700 text-base bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-              value={selectedVoice}
-              onChange={(e) => setSelectedVoice(e.target.value)}
-            >
-              {voices
-                .filter((v) => v.lang === "en-US")
-                .map((v) => (
-                  <option key={v.name} value={v.name}>
-                    {v.name} ({v.lang})
-                  </option>
-                ))}
-            </select>
-          </div>
+          {/* 音声選択UI (now handled by SettingsModal) */}
           <button
             className="flex items-center gap-2 px-6 py-2 bg-gradient-to-r from-green-400 to-blue-500 text-white rounded-full shadow-md hover:scale-105 hover:shadow-lg transition-all font-bold text-lg"
             onClick={speak}
@@ -339,6 +325,13 @@ export default function DictationPage() {
           )}
         </section>
       </div>
+      <SettingsModal
+        isOpen={isSettingsModalOpen}
+        onClose={() => setIsSettingsModalOpen(false)}
+        voices={voices}
+        selectedVoice={selectedVoice}
+        onVoiceChange={setSelectedVoice}
+      />
     </main>
   )
 }

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SettingsModal from './SettingsModal';
+
+// Mock SpeechSynthesisVoice type as it might not be available in JSDOM
+interface MockSpeechSynthesisVoice {
+  name: string;
+  lang: string;
+  default: boolean;
+  localService: boolean;
+  voiceURI: string;
+}
+
+const mockVoices: MockSpeechSynthesisVoice[] = [
+  { name: "Test Voice 1", lang: "en-US", default: false, localService: true, voiceURI: "test-voice-1" },
+  { name: "Test Voice 2", lang: "en-GB", default: false, localService: true, voiceURI: "test-voice-2" },
+  { name: "US English Samantha", lang: "en-US", default: true, localService: true, voiceURI: "samantha" },
+];
+
+describe('SettingsModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnVoiceChange = jest.fn();
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    mockOnClose.mockClear();
+    mockOnVoiceChange.mockClear();
+  });
+
+  test('does not render when isOpen is false', () => {
+    render(
+      <SettingsModal
+        isOpen={false}
+        onClose={mockOnClose}
+        voices={mockVoices as SpeechSynthesisVoice[]}
+        selectedVoice={mockVoices[0].name}
+        onVoiceChange={mockOnVoiceChange}
+      />
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+  });
+
+  test('renders correctly when isOpen is true', () => {
+    render(
+      <SettingsModal
+        isOpen={true}
+        onClose={mockOnClose}
+        voices={mockVoices as SpeechSynthesisVoice[]}
+        selectedVoice={mockVoices[0].name}
+        onVoiceChange={mockOnVoiceChange}
+      />
+    );
+    // Using 'dialog' role implicitly added by the browser for such structures,
+    // or we can add an explicit role="dialog" to the modal container for robustness.
+    // For now, let's check for the title, which is a strong indicator.
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByLabelText('Voice:')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+  });
+
+  test('populates voice selection dropdown with provided voices', () => {
+    render(
+      <SettingsModal
+        isOpen={true}
+        onClose={mockOnClose}
+        voices={mockVoices as SpeechSynthesisVoice[]}
+        selectedVoice={mockVoices[0].name}
+        onVoiceChange={mockOnVoiceChange}
+      />
+    );
+    const voiceSelect = screen.getByLabelText('Voice:') as HTMLSelectElement;
+    expect(voiceSelect.options.length).toBe(mockVoices.length);
+    mockVoices.forEach((voice, index) => {
+      expect(voiceSelect.options[index].value).toBe(voice.name);
+      expect(voiceSelect.options[index].text).toBe(`${voice.name} (${voice.lang})`);
+    });
+  });
+
+  test('shows the correct voice as selected', () => {
+    const selectedVoiceName = mockVoices[1].name;
+    render(
+      <SettingsModal
+        isOpen={true}
+        onClose={mockOnClose}
+        voices={mockVoices as SpeechSynthesisVoice[]}
+        selectedVoice={selectedVoiceName}
+        onVoiceChange={mockOnVoiceChange}
+      />
+    );
+    const voiceSelect = screen.getByLabelText('Voice:') as HTMLSelectElement;
+    expect(voiceSelect.value).toBe(selectedVoiceName);
+  });
+
+  test('calls onVoiceChange with the new voice name when selection changes', () => {
+    const initialVoice = mockVoices[0].name;
+    const newVoiceToSelect = mockVoices[1].name;
+    render(
+      <SettingsModal
+        isOpen={true}
+        onClose={mockOnClose}
+        voices={mockVoices as SpeechSynthesisVoice[]}
+        selectedVoice={initialVoice}
+        onVoiceChange={mockOnVoiceChange}
+      />
+    );
+    const voiceSelect = screen.getByLabelText('Voice:');
+    fireEvent.change(voiceSelect, { target: { value: newVoiceToSelect } });
+    expect(mockOnVoiceChange).toHaveBeenCalledTimes(1);
+    expect(mockOnVoiceChange).toHaveBeenCalledWith(newVoiceToSelect);
+  });
+
+  test('calls onClose when the "Done" button is clicked', () => {
+    render(
+      <SettingsModal
+        isOpen={true}
+        onClose={mockOnClose}
+        voices={mockVoices as SpeechSynthesisVoice[]}
+        selectedVoice={mockVoices[0].name}
+        onVoiceChange={mockOnVoiceChange}
+      />
+    );
+    const doneButton = screen.getByRole('button', { name: 'Done' });
+    fireEvent.click(doneButton);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+interface SettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  voices: SpeechSynthesisVoice[];
+  selectedVoice: string;
+  onVoiceChange: (voiceName: string) => void;
+}
+
+const SettingsModal: React.FC<SettingsModalProps> = ({
+  isOpen,
+  onClose,
+  voices,
+  selectedVoice,
+  onVoiceChange,
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 p-8 rounded-xl shadow-2xl max-w-md w-full">
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">Settings</h2>
+        
+        <div className="mb-6">
+          <label htmlFor="voice-select" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Voice:
+          </label>
+          <select
+            id="voice-select"
+            value={selectedVoice}
+            onChange={(e) => onVoiceChange(e.target.value)}
+            className="w-full p-2.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors duration-150 ease-in-out"
+          >
+            {voices.map((voice) => (
+              <option key={voice.name} value={voice.name}>
+                {voice.name} ({voice.lang})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button
+          onClick={onClose}
+          className="mt-8 w-full px-4 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-lg shadow-md transition-colors duration-150 ease-in-out focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsModal;


### PR DESCRIPTION
This commit introduces a new settings modal that allows you to change audio-related settings.

Key changes:
- Created a `SettingsModal` React component in `src/components/SettingsModal.tsx`.
- The modal includes a dropdown for selecting the speech synthesis voice.
- Added a "Settings" button to the main page (`src/app/page.tsx`) to open the modal.
- The modal's visibility is managed by state in the main page component.
- Voice selection logic has been moved into the modal, and the old inline UI has been removed.
- Styled the modal using Tailwind CSS for a polished and consistent look and feel.
- Added unit tests for the `SettingsModal` component using Jest and React Testing Library to ensure functionality and prevent regressions.